### PR TITLE
Relay address query by short 6-code abbreviation/suffix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ cache:
   cargo: true
   timeout: 240
   directories:
-  - "$HOME/.cargo" - "$TRAVIS_BUILD_DIR/rust/target"
+  - "$HOME/.cargo"
+  - "$TRAVIS_BUILD_DIR/rust/target"
 
 env:
   global:
   - RUST_BACKTRACE="1"
   - RUSTFLAGS="-C debug-assertions"
-  - OPENSSL_DIR="/usr/local/opt/openssl"
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,39 @@
 # cocoa_grinwallet
 IOS Grin Wallet Pod
 
+## How to import this pod
+
+Add one line into your `Podfile`:
+```Bash
+  pod 'cocoa_grinwallet', :git => 'https://github.com/gottstech/cocoa_grinwallet.git', :tag => 'v1.0.4'
+```
+then run `pod install`
+
+After the pod installation, remember to manually download the libraries to avoid a long building procedure. The libraries can be found in the [release](https://github.com/gottstech/cocoa_grinwallet/releases) page of this repo.
+
+<details>
+ <summary>download script</summary>
+
+```Bash
+#!/bin/bash
+
+version=`grep " pod 'cocoa_grinwallet'" Podfile | sed "s/.*:tag => '\(.*\)'/\1/"`
+
+mkdir -p Pods/cocoa_grinwallet/cocoa_grinwallet/Library && cd Pods/cocoa_grinwallet/cocoa_grinwallet/Library && rm -f libgrinwallet* || exit 1
+
+wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_aarch64-apple-ios.a || exit 1
+
+wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_armv7s-apple-ios.a || exit 1
+
+wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_x86_64-apple-ios.a || exit 1
+
+printf "3 libs have been downloaded successfully\n"
+
+cd - > /dev/null || exit 1
+ls -l Pods/cocoa_grinwallet/cocoa_grinwallet/Library
+```
+</details>
+
 ## Build
 ### Set up the environment
 
@@ -33,56 +66,20 @@ cargo install cargo-lipo
 ```Bash
 git clone --recursive https://github.com/gottstech/cocoa_grinwallet.git
 cd cocoa_grinwallet/rust
-export OPENSSL_DIR="/usr/local/opt/openssl"
 cargo lipo --release --targets aarch64-apple-ios,x86_64-apple-ios,armv7s-apple-ios
 ./copy_libs.sh
 ```
 
 Note:
 - The generated libs are in `Library/` folder.
-- If don't have openssl installed, please run:
-  - For Mac: `brew install openssl`
-  - For Linux: `sudo apt install libssl-dev`
   
-### On IOS Application Side
-
-Add the following 2 lines into your `Podfile`:
-```Bash
-  pod 'cocoa_grinwallet', :git => 'https://github.com/gottstech/cocoa_grinwallet.git', :tag => 'v1.0.2'
-  pod 'OpenSSL', '~> 1.0'
-```
-then run `pod install`
-
-If you have problem for OpenSSL pod installation, please refer to [this post](https://stackoverflow.com/a/57196786/3831478) to solve it.  
-
-After the pod installation, remember to manually download the libraries to avoid a long building procedure. The libraries can be found in the [release](https://github.com/gottstech/cocoa_grinwallet/releases) page of this repo.
-
-```Bash
-#!/bin/bash
-
-version=`grep " pod 'cocoa_grinwallet'" Podfile | sed "s/.*:tag => '\(.*\)'/\1/"`
-
-mkdir -p Pods/cocoa_grinwallet/cocoa_grinwallet/Library && cd Pods/cocoa_grinwallet/cocoa_grinwallet/Library && rm -f libgrinwallet* || exit 1
-
-wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_aarch64-apple-ios.a || exit 1
-
-wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_armv7s-apple-ios.a || exit 1
-
-wget https://github.com/gottstech/cocoa_grinwallet/releases/download/${version}/libgrinwallet_x86_64-apple-ios.a || exit 1
-
-printf "3 libs have been downloaded successfully\n"
-
-cd - > /dev/null || exit 1
-ls -l Pods/cocoa_grinwallet/cocoa_grinwallet/Library
-```
-
 ## License
 
 Apache License v2.0.
 
 ## Credits
 
-The code was using the [Ironbelly](https://github.com/cyclefortytwo/ironbelly) as the reference.
+The code was using the [Ironbelly](https://github.com/cyclefortytwo/ironbelly) as the initial reference.
 
 The related code taken with thanks and respect, with license details in all derived source files.
 

--- a/cocoa_grinwallet.podspec
+++ b/cocoa_grinwallet.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'cocoa_grinwallet'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'Grin Wallet IOS Libs. With embedded Grin Relay service.'
 
 # This description is used to generate tags and improve search results.

--- a/cocoa_grinwallet/Classes/grinwallet.h
+++ b/cocoa_grinwallet/Classes/grinwallet.h
@@ -19,6 +19,11 @@
 
 void cstr_free(const char *s);
 
+const char*  select_nearest_node(
+    const char* check_node_api_http_addr,
+    uint8_t *error
+);
+
 const char*  grin_check_password(
     const char* json_cfg,
     const char* password,

--- a/cocoa_grinwallet/Classes/grinwallet.h
+++ b/cocoa_grinwallet/Classes/grinwallet.h
@@ -25,6 +25,13 @@ const char*  grin_check_password(
     uint8_t *error
 );
 
+const char*  grin_wallet_change_password(
+    const char* json_cfg,
+    const char* old_password,
+    const char* new_password,
+    uint8_t *error
+);
+
 const char* grin_init_wallet_seed(uint8_t *error);
 
 const char* grin_wallet_init(
@@ -92,8 +99,14 @@ const char* grin_listen(
     uint8_t *error
 );
 
-const char* grin_relay_addr(
+const char* my_grin_relay_addr(
     const char* json_cfg,
+    uint8_t *error
+);
+
+const char* grin_relay_addr_query(
+    const char* json_cfg,
+    const char* six_code_suffix,
     uint8_t *error
 );
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -322,21 +322,21 @@ dependencies = [
 
 [[package]]
 name = "cocoa_grinwallet"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_controller 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_controller 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "linefeed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -497,6 +497,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,19 +607,6 @@ dependencies = [
 [[package]]
 name = "fnv"
 version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -888,8 +885,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -897,33 +894,35 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_controller 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_controller 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet_api"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -931,12 +930,16 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -944,27 +947,29 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -978,17 +983,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1003,18 +1009,19 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1025,22 +1032,21 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_relay"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1051,14 +1057,13 @@ dependencies = [
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet_util"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.2"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
 dependencies = [
  "backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1755,31 +1760,6 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "openssl"
-version = "0.10.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2376,17 @@ dependencies = [
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -3072,7 +3063,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3186,6 +3176,7 @@ dependencies = [
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+"checksum dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4a851f8e0ed5790b60ded487feb0dc3c7e7da52c4a0adc57c009bfc5af8ca1a"
 "checksum easy-jsonrpc-proc-macro 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9fb33793846951f339a70580375734416898ff8ddbb74401865031e25ba6751"
@@ -3198,8 +3189,6 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -3219,14 +3208,14 @@ dependencies = [
 "checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
 "checksum grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa52e6084944cc6c67999461e763c94feaca4ff579050f85f8b79c367b15fb96"
 "checksum grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa78064c94d7331b7be4ffeed45e3341235244bac6573dda9d508abb26eba6d"
-"checksum grin_wallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_controller 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
+"checksum grin_wallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_controller 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
 "checksum h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "69b2a5a3092cbebbc951fe55408402e696ee2ed09019137d1800fc2c411265d2"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -3298,8 +3287,6 @@ dependencies = [
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-"checksum openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8152bb5a9b5b721538462336e3bef9a539f892715e5037fda0f984577311af15"
-"checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
@@ -3373,6 +3360,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallstr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa65bb4d5b2bbc90d36af64e29802f788aa614783fa1d0df011800ddcec6e8e"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "linefeed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cocoa_grinwallet"
 version = "1.0.3"
-authors = ["Gary Yu"]
+authors = ["Gary Yu <gairy.yu@gmail.com>"]
 description = "Grin Wallet IOS Libs. With embedded Grin Relay service."
+license = "Apache-2.0"
 publish = false
 edition = "2018"
 
@@ -21,14 +22,14 @@ serde_json = "1"
 uuid = "0.7.4"
 
 # Normal using
-grin_wallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_api = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_config = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_controller = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_impls = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_libwallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_util = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_relay = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
+grin_wallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_api = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_config = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_controller = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_impls = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_libwallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_util = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet_relay = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
 
 # In case of local development
 #grin_wallet_api = { path = "../../grin-wallet/api" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocoa_grinwallet"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Gary Yu <gairy.yu@gmail.com>"]
 description = "Grin Wallet IOS Libs. With embedded Grin Relay service."
 license = "Apache-2.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ failure_derive = "0.1"
 linefeed = "0.6"
 log = "0.4"
 prettytable-rs = "0.7"
+regex = "1"
 rpassword = "2.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -35,7 +35,7 @@ use grin_wallet_libwallet::api_impl::types::InitTxArgs;
 use grin_wallet_libwallet::{NodeClient, WalletInst, SlateVersion, VersionedSlate};
 use grin_wallet_util::grin_core::global::ChainTypes;
 use grin_wallet_util::grin_keychain::ExtKeychain;
-use grin_wallet_util::grin_util::{file::get_first_line, Mutex, ZeroingString};
+use grin_wallet_util::grin_util::{Mutex, ZeroingString};
 use grin_wallet_controller::{grinrelay_address, grinrelay_listener};
 
 /// Default minimum confirmation
@@ -96,6 +96,7 @@ struct MobileWalletCfg {
     chain_type: String,
     data_dir: String,
     node_api_addr: String,
+    node_api_secret: String,
     password: String,
     minimum_confirmations: u64,
     grinrelay_config: Option<GrinRelayConfig>,
@@ -125,7 +126,7 @@ fn new_wallet_config(config: MobileWalletCfg) -> Result<WalletConfig, Error> {
         api_listen_port: 3415,
         owner_api_listen_port: Some(3420),
         api_secret_path: Some(".api_secret".to_string()),
-        node_api_secret_path: Some(config.data_dir.clone() + "/.api_secret"),
+        node_api_secret: Some(config.node_api_secret),
         check_node_api_http_addr: config.node_api_addr,
         owner_api_include_foreign: Some(false),
         data_file_dir: config.data_dir + "/wallet_data",
@@ -166,7 +167,7 @@ pub extern "C" fn grin_init_wallet_seed(error: *mut u8) -> *const c_char {
 
 fn wallet_init(json_cfg: &str, password: &str, is_12_phrases: bool) -> Result<String, Error> {
     let wallet_config = new_wallet_config(MobileWalletCfg::from_str(json_cfg)?)?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let seed_length = if is_12_phrases { 16 } else { 32 };
     let seed = WalletSeed::init_file(&wallet_config.data_file_dir, seed_length, None, password, false)?;
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
@@ -190,7 +191,7 @@ fn wallet_init_recover(json_cfg: &str, mnemonic: &str) -> Result<String, Error> 
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet_config = new_wallet_config(config.clone())?;
     WalletSeed::recover_from_phrase(&wallet_config.data_file_dir, mnemonic, config.password.as_str())?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
     let _: LMDBBackend<HTTPNodeClient, ExtKeychain> =
         LMDBBackend::new(wallet_config, config.password.as_str(), node_client)?;
@@ -245,7 +246,7 @@ fn wallet_restore(
 ) -> Result<String, Error> {
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet_config = new_wallet_config(config.clone())?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
     let wallet = instantiate_wallet(wallet_config, node_client, config.password.as_str(), &config.account)?;
     let api = Owner::new(wallet.clone());
@@ -332,7 +333,7 @@ fn get_wallet_instance(
     config: MobileWalletCfg,
 ) -> Result<Arc<Mutex<WalletInst<impl NodeClient, ExtKeychain>>>, Error> {
     let wallet_config = new_wallet_config(config.clone())?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
 
     instantiate_wallet(
@@ -485,11 +486,12 @@ fn listen(
     let (relay_tx_as_payee, relay_rx) = channel();
 
     // Start a Grin Relay service firstly
-    let grinrelay_listener = grinrelay_listener(
+    let (grinrelay_key_path, grinrelay_listener) = grinrelay_listener(
         wallet.clone(),
         config.grinrelay_config.clone().unwrap_or_default(),
         None,
         Some(relay_tx_as_payee),
+        None,
     )?;
 
     let _handle = thread::spawn(move || {
@@ -499,7 +501,7 @@ fn listen(
                 Ok((addr, slate)) => {
                     let _slate_id = slate.id;
                     if api.verify_slate_messages(&slate).is_ok() {
-                        let slate_rx = api.receive_tx(&slate, Some(&config.account), None);
+                        let slate_rx = api.receive_tx(&slate, Some(&config.account), None, Some(grinrelay_key_path));
                         if let Ok(slate_rx) = slate_rx {
                             let versioned_slate =
                                 VersionedSlate::into_version(slate_rx.clone(), SlateVersion::V2);
@@ -595,29 +597,23 @@ fn send_tx_by_http(
     let slate_r1 = api.init_send_tx(args)?;
 
     let adapter = HTTPWalletCommAdapter::new();
-    match adapter.send_tx_sync(receiver_wallet_url, &slate_r1) {
-        Ok(slate) => {
-            api.verify_slate_messages(&slate)?;
-            api.tx_lock_outputs(&slate_r1, 0)?;
+    let (slate, _tx_proof) = adapter.send_tx_sync(receiver_wallet_url, &slate_r1)?;
+    api.verify_slate_messages(&slate)?;
+    api.tx_lock_outputs(&slate_r1, 0)?;
 
-            let finalized_slate = api.finalize_tx(&slate);
-            if finalized_slate.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-            }
-            let finalized_slate = finalized_slate?;
-
-            let res = api.post_tx(&finalized_slate.tx, false);
-            if res.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-                res?;
-            }
-
-            Ok(serde_json::to_string(&finalized_slate).expect("fail to serialize slate to json string"))
-        }
-        Err(e) => {
-            Err(Error::from(e))
-        }
+    let finalized_slate = api.finalize_tx(&slate, None, None);
+    if finalized_slate.is_err() {
+        api.cancel_tx(None, Some(slate_r1.id))?;
     }
+    let finalized_slate = finalized_slate?;
+
+    let res = api.post_tx(&finalized_slate.tx, false);
+    if res.is_err() {
+        api.cancel_tx(None, Some(slate_r1.id))?;
+        res?;
+    }
+
+    Ok(serde_json::to_string(&finalized_slate).expect("fail to serialize slate to json string"))
 }
 
 fn send_tx_by_relay(
@@ -649,38 +645,33 @@ fn send_tx_by_relay(
     let (relay_tx_as_payer, relay_rx) = channel();
 
     // Start a Grin Relay service firstly
-    let grinrelay_listener = grinrelay_listener(
+    let (grinrelay_key_path, grinrelay_listener) = grinrelay_listener(
         wallet.clone(),
         config.grinrelay_config.clone().unwrap_or_default(),
         Some(relay_tx_as_payer),
+        None,
         None,
     )?;
     thread::sleep(Duration::from_millis(1_000));
 
     let adapter = GrinrelayWalletCommAdapter::new(grinrelay_listener, relay_rx);
-    match adapter.send_tx_sync(receiver_addr, &slate_r1.clone()) {
-        Ok(mut slate) => {
-            api.verify_slate_messages(&slate)?;
-            api.tx_lock_outputs(&slate_r1, 0)?;
+    let (slate, tx_proof) = adapter.send_tx_sync(receiver_addr, &slate_r1.clone())?;
+    api.verify_slate_messages(&slate)?;
+    api.tx_lock_outputs(&slate_r1, 0)?;
 
-            let finalized_slate = api.finalize_tx(&mut slate);
-            if finalized_slate.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-            }
-            let finalized_slate = finalized_slate?;
-
-            let res = api.post_tx(&finalized_slate.tx, false);
-            if res.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-                res?;
-            }
-
-            Ok(serde_json::to_string(&finalized_slate).expect("fail to serialize slate to json string"))
-        }
-        Err(e) => {
-            Err(Error::from(e))
-        }
+    let finalized_slate = api.finalize_tx(&slate, tx_proof, Some(grinrelay_key_path));
+    if finalized_slate.is_err() {
+        api.cancel_tx(None, Some(slate_r1.id))?;
     }
+    let finalized_slate = finalized_slate?;
+
+    let res = api.post_tx(&finalized_slate.tx, false);
+    if res.is_err() {
+        api.cancel_tx(None, Some(slate_r1.id))?;
+        res?;
+    }
+
+    Ok(serde_json::to_string(&finalized_slate).expect("fail to serialize slate to json string"))
 }
 
 #[no_mangle]
@@ -790,7 +781,7 @@ fn tx_file_receive(
     let adapter = FileWalletCommAdapter::new();
     let mut slate = adapter.receive_tx_async(&slate_file_path)?;
     api.verify_slate_messages(&slate)?;
-    slate = api.receive_tx(&slate, Some(&config.account), Some(message.to_string()))?;
+    slate = api.receive_tx(&slate, Some(&config.account), Some(message.to_string()), None)?;
     Ok(serde_json::to_string(&slate).expect("fail to serialize slate to json string"))
 }
 
@@ -818,7 +809,7 @@ fn tx_file_finalize(
     let adapter = FileWalletCommAdapter::new();
     let mut slate = adapter.receive_tx_async(slate_file_path)?;
     api.verify_slate_messages(&slate)?;
-    slate = api.finalize_tx(&slate)?;
+    slate = api.finalize_tx(&slate, None, None)?;
     Ok(serde_json::to_string(&slate).expect("fail to serialize slate to json string"))
 }
 


### PR DESCRIPTION
- Adaptation for `GrinWallet+` API version `2.0.2-beta.2`
- New API `grin_relay_addr_query` for 6-code address query
- New API `select_nearest_node` for default nodes selection
- Bump the version number to 1.0.4

