### PR TITLE
Update grin-wallet crates to v2.0.1-beta.4

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -322,21 +322,21 @@ dependencies = [
 
 [[package]]
 name = "cocoa_grinwallet"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_controller 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_controller 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "linefeed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -394,6 +394,27 @@ dependencies = [
  "bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -683,18 +704,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin_api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_p2p 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_pool 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_p2p 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_pool 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -715,8 +736,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,10 +745,10 @@ dependencies = [
  "croaring 0.3.9",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -738,18 +759,19 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9",
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -765,13 +787,13 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -788,17 +810,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,17 +832,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -844,16 +866,16 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -865,8 +887,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,13 +903,13 @@ dependencies = [
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -895,13 +917,13 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_controller 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_controller 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -912,18 +934,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -931,13 +953,13 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,8 +970,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -958,12 +980,12 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -984,18 +1006,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1010,15 +1032,16 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1033,8 +1056,8 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_relay"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1043,8 +1066,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
- "grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1063,17 +1086,17 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "2.0.1-beta.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2#bfee7fa7fe3ea5b7c9b8a88e35dcd9ac122766f5"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_api 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,15 +1558,6 @@ dependencies = [
  "terminfo 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "msdos_time"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3113,12 +3127,11 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.4.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -3166,6 +3179,8 @@ dependencies = [
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+"checksum crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b14492071ca110999a20bf90e3833406d5d66bfd93b4e52ec9539025ff43fe0d"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
@@ -3200,23 +3215,23 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "924b2e7d2986e625dcad89e8a429a7b3adee3c3d71e585f4a66c4f7e78715e31"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_api 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24adb039b0894e95c6bfe0ac0df7f3b8dc48be696cb37798024b685ca36b3923"
-"checksum grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ae81b6a498f5d3d8c1c2f105e600d427a1717c76c282ab20e3e5eb2a35aab25"
-"checksum grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06ba34fba8ea38a3ff38701761a6933649102a044f2686c21ba3947d0251aacf"
-"checksum grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1442f932b7488ef1bcf56eb812995cb0f0ad181ef8f08d9315954cd14929267"
-"checksum grin_p2p 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1483ca17f8479cffd360c4093f01e4a2700424bc9c07ff598de7d1805494d1e6"
-"checksum grin_pool 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6057c01cac340e54a24749e688955712289381722a9efc225ccbaaff836996"
+"checksum grin_api 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_p2p 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_pool 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
-"checksum grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa52e6084944cc6c67999461e763c94feaca4ff579050f85f8b79c367b15fb96"
-"checksum grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa78064c94d7331b7be4ffeed45e3341235244bac6573dda9d508abb26eba6d"
-"checksum grin_wallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_api 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_config 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_controller 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_impls 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_libwallet 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_relay 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
-"checksum grin_wallet_util 2.0.1-beta.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.2)" = "<none>"
+"checksum grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_wallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_controller 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
 "checksum h2 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "69b2a5a3092cbebbc951fe55408402e696ee2ed09019137d1800fc2c411265d2"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -3264,7 +3279,6 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mortal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26153280e6a955881f761354b130aa7838f9983836f3de438ac0a8f22cfab1ff"
 "checksum mortal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b4fc78ee0ff9757c7d510f7fa68d66ec0133aa0b07493252a3c13c00facf023"
-"checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
@@ -3443,4 +3457,4 @@ dependencies = [
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2ea4afc22e9497e26b42bf047083c30f7e3ca566f3bcd7187f83d18b327043"
 "checksum zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afd1469e4bbca3b96606d26ba6e9bd6d3aed3b1299c82b92ec94377d22d78dbc"
-"checksum zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "36b9e08fb518a65cf7e08a1e482573eb87a2f4f8c6619316612a3c1f162fe822"
+"checksum zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c21bb410afa2bd823a047f5bda3adb62f51074ac7e06263b2c97ecdd47e9fc6"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocoa_grinwallet"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Gary Yu <gairy.yu@gmail.com>"]
 description = "Grin Wallet IOS Libs. With embedded Grin Relay service."
 license = "Apache-2.0"
@@ -23,14 +23,14 @@ serde_json = "1"
 uuid = "0.7.4"
 
 # Normal using
-grin_wallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_api = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_config = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_controller = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_impls = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_libwallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_util = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
-grin_wallet_relay = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.2" }
+grin_wallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_api = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_config = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_controller = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_impls = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_libwallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_util = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_relay = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
 
 # In case of local development
 #grin_wallet_api = { path = "../../grin-wallet/api" }


### PR DESCRIPTION
Refers to https://github.com/gottstech/grin-wallet/releases/tag/v2.0.1-beta.4

And the corresponding modifications for mobile wallet lib.